### PR TITLE
chore: misc fixes

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,10 +4,13 @@ const docsRoot = "https://docs.boltz.exchange";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "Boltz API",
-  description: "Boltz API Docs",
+  title: "Boltz Docs",
+  description: "Boltz Docs",
+  head: [
+    ['link', { rel: 'icon', href: '/assets/logo.svg' }],
+  ],
   themeConfig: {
-    logo: "./assets/logo.svg",
+    logo: "/assets/logo.svg",
     search: {
       provider: "local",
     },
@@ -15,22 +18,6 @@ export default defineConfig({
       {
         icon: "github",
         link: "https://github.com/BoltzExchange",
-      },
-      {
-        icon: "discord",
-        link: "https://discord.gg/QBvZGcW",
-      },
-      {
-        icon: "telegram",
-        link: "https://t.me/boltzhq",
-      },
-      {
-        icon: "substack",
-        link: "https://blog.boltz.exchange",
-      },
-      {
-        icon: "twitter",
-        link: "https://twitter.com/boltzhq",
       },
     ],
   },


### PR DESCRIPTION
- Fixed page title and description title: Changed from "Boltz API" to "Boltz Docs", this is the Docs Home that contains more than only API
- Fixed logo path: Changed from "./assets/logo.svg" to "/assets/logo.svg" to (hopefully) work on GitHub Pages, as-is it doesn't and the intern said it's probably due to the relative path.
- Added logo as favicon while I was at it
- Removed social links (too cluttered, outdated logos plus we already link to all of them in the "Resources" section)